### PR TITLE
Specifying PROXY configuration on Connection class

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -43,9 +43,9 @@ class TestConsumer(unittest.TestCase):
             # the 307
             post.assert_has_calls([
                 mock.call('url', data=payload,
-                    headers={'auth': 'fake'}, stream=True, cookies=None),
+                    headers={'auth': 'fake'}, stream=True, cookies=None, proxies=None),
                 mock.call('url', data=payload,
-                    headers={'auth': 'fake'}, stream=True, cookies={'foo': 'bar'}),
+                    headers={'auth': 'fake'}, stream=True, cookies={'foo': 'bar'}, proxies=None),
             ])
 
     def test_connect_failure_retry(self):

--- a/uaconnect/consumer.py
+++ b/uaconnect/consumer.py
@@ -126,7 +126,7 @@ class Connection(object):
             try:
                 self._conn = requests.post(self.url, data=body,
                         headers=self._headers(), stream=True,
-                        cookies=self.cookies)
+                        cookies=self.cookies, proxies=self.proxies)
                 if self._conn.status_code == 307:
                     logging.info("Handling redirect, retrying [%s]", attempts)
                     self.cookies = self._conn.cookies

--- a/uaconnect/consumer.py
+++ b/uaconnect/consumer.py
@@ -81,10 +81,11 @@ class Connection(object):
     url = None
     cookies = None
 
-    def __init__(self, app_key, access_token, url):
+    def __init__(self, app_key, access_token, url, proxies=None):
         self.app_key = app_key
         self.access_token = access_token
         self.url = url
+        self.proxies = proxies
 
     def close(self):
         if not self._conn.raw.closed:
@@ -161,7 +162,7 @@ class Consumer(object):
     offset = 'LATEST'
     filters = None
 
-    def __init__(self, app_key, access_token, recorder, url=None):
+    def __init__(self, app_key, access_token, recorder, url=None, proxies=None):
         self.app_key = app_key
         self.access_token = access_token
         self.recorder = recorder
@@ -170,7 +171,7 @@ class Consumer(object):
         else:
             self.url = CONNECT_URL
         self.outstanding = collections.OrderedDict()
-        self.connection = Connection(app_key, access_token, self.url)
+        self.connection = Connection(app_key, access_token, self.url, proxies=proxies)
         self.filters = []
 
     def _record(self, event):


### PR DESCRIPTION
This PR enables the Proxy configuration at the creation time of the Consumer. 

Sometimes you need to use a specific proxy to reach out different types of hosts and protocols, so, set the venv  HTTPS_PROXY or HTTP_PROXY to declare a proxy is not an option. 